### PR TITLE
Minor typoo fix for main.txt

### DIFF
--- a/expression2/Self-Updatable Kernel/main.txt
+++ b/expression2/Self-Updatable Kernel/main.txt
@@ -74,7 +74,7 @@ if(clk("Request from HTTP")){
 if(httpClk()){
 
     # Local variables store relevant URL & HTTP data.
-    local CallbackURL_Str = httpRequestURL()
+    local CallbackURL_Str = httpRequestUrl()
     local Data_Str = httpData()
 
     # Switch-case deals with the returned HTTP data, according to which URL requested it.


### PR DESCRIPTION
Fixed a minor typo in line 77, with the function 'httpRequestURL()' to 'httpRequestUrl()'.